### PR TITLE
1 feature convert back trees to iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "iter-tree"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 
-description = "Convert iterators to tree structures"
+description = "Convert between iterators and tree structures in both directions"
 repository = "https://github.com/ThibSrb/iter-tree"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This library provides an easy way to convert between iterators and tree structur
 
 It extends iterators with two functions : 
 
-- `tree` that maps the iterator to an iterator of `Tree` that can be collected to a `Tree`.
+- `tree` that maps the iterator to an iterator of Tree that can be collected to a `Tree`.
 
 - `tree_deque` that maps the iterator to an iterator of `TreeDeque` that can be collected to a `TreeDeque`.
-  To get this one, you have to activate the `deque` feature flag.
+  
+   To get this one, you have to activate the `deque` feature flag.
 
 Both type of trees implement the `IntoIterator` trait.
 
@@ -16,19 +17,19 @@ Both type of trees implement the `IntoIterator` trait.
 The creation of a tree is controlled with the `BranchControl` enum.
 This enum has three variants :
 
-- BranchControl::Start
+- `BranchControl::Start`
   - Is used to start nesting the items of the iterator into a new branch.
-- BranchControl::Continue
+- `BranchControl::Continue`
   - Is used to keep the item in the same branch as the previous ones
-- BranchControl::End
+- `BranchControl::End`
   - Is used to get back up to the previous branch to put the next items.
 
-> Note:
-> 
-> When filling a branch started with `BranchControl::Start`, no crash or error will happens if the iterator ends before encountering the corresponding `BranchControl::End`.
-> Similarly, any unmatched `BranchControl::End` will simply be ignored.
-> 
-> If you want to check for these kind of situations, you can use a trick such as the depth counter showed in the below example.
+Note:
+
+When filling a branch started with `BranchControl::Start`, no crash or error will happens if the iterator ends before encountering the corresponding `BranchControl::End`.
+Similarly, any unmatched `BranchControl::End` will simply be ignored.
+
+If you want to check for these kind of situations, you can use a trick such as the depth counter showed in the below example.
 
 ## Example
 
@@ -39,7 +40,7 @@ let mut depth = 0;
 
 let before = String::from("a+(b+c)+d");
 
-let tree = before
+let tree: Tree<char> = before
     .chars()
     .into_iter()
     .tree(|&item: &char| match item {
@@ -53,7 +54,7 @@ let tree = before
         },
         _ => BranchControl::Continue,
     })
-    .collect::<Tree<char>>();
+    .collect();
 
 println!("{tree:#?}");
 
@@ -100,7 +101,7 @@ Branch(
 )
 ```
 
-#### Controllers
+#### `Controller`s
 
 Additionally you can create a struct that implements the `Controller` trait to replace the closure from the previous example.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,35 @@
 //! # iter-tree
 //!
 //! This library provides an easy way to convert between iterators and tree structures in both directions. This can be useful when building simple parsers to convert a stream of token into a tree of token.
-
+//!
 //! It extends iterators with two functions : 
 //! 
-//! - `tree` that maps the iterator to an iterator of `Tree` that can be collected to a `Tree`.
+//! - [`tree`](tree::Treeable::tree) that maps the iterator to an iterator of [`Tree`](tree::Tree) that can be collected to a [`Tree`](tree::Tree).
 //! 
-//! - `tree_deque` that maps the iterator to an iterator of `TreeDeque` that can be collected to a `TreeDeque`.
-//!   To get this one, you have to activate the `deque` feature flag.
+//! - [`tree_deque`](tree_deque::TreeDequeable::tree_deque) that maps the iterator to an iterator of [`TreeDeque`](tree_deque::TreeDeque) that can be collected to a [`TreeDeque`](tree_deque::TreeDeque).
+//!   
+//!    To get this one, you have to activate the `deque` feature flag.
 //!
-//! Both type of trees implement the `IntoIterator` trait.
+//! Both type of trees implement the [`IntoIterator`] trait.
 //!
 //! ## Usage
 //!
-//! The creation of a tree is controlled with the `BranchControl` enum.
+//! The creation of a tree is controlled with the [`BranchControl`](controller::BranchControl) enum.
 //! This enum has three variants :
 //!
-//! - BranchControl::Start
+//! - [`BranchControl::Start`](controller::BranchControl::Start)
 //!   - Is used to start nesting the items of the iterator into a new branch.
-//! - BranchControl::Continue
+//! - [`BranchControl::Continue`](controller::BranchControl::Continue)
 //!   - Is used to keep the item in the same branch as the previous ones
-//! - BranchControl::End
+//! - [`BranchControl::End`](controller::BranchControl::End)
 //!   - Is used to get back up to the previous branch to put the next items.
 //!
-//! > Note:
-//! > 
-//! > When filling a branch started with `BranchControl::Start`, no crash or error will happens if the iterator ends before encountering the corresponding `BranchControl::End`.
-//! > Similarly, any unmatched `BranchControl::End` will simply be ignored.
-//! > 
-//! > If you want to check for these kind of situations, you can use a trick such as the depth counter showed in the below example.
+//! Note:
+//!
+//! When filling a branch started with [`BranchControl::Start`](controller::BranchControl::Start), no crash or error will happens if the iterator ends before encountering the corresponding [`BranchControl::End`](controller::BranchControl::End).
+//! Similarly, any unmatched [`BranchControl::End`](controller::BranchControl::End) will simply be ignored.
+//!
+//! If you want to check for these kind of situations, you can use a trick such as the depth counter showed in the below example.
 //!
 //! ## Example
 //!
@@ -39,7 +40,7 @@
 //!
 //! let before = String::from("a+(b+c)+d");
 //!
-//! let tree = before
+//! let tree: Tree<char> = before
 //!     .chars()
 //!     .into_iter()
 //!     .tree(|&item: &char| match item {
@@ -53,7 +54,7 @@
 //!         },
 //!         _ => BranchControl::Continue,
 //!     })
-//!     .collect::<Tree<char>>();
+//!     .collect();
 //!
 //! println!("{tree:#?}");
 //!
@@ -100,9 +101,9 @@
 //! )
 //! ```
 //!
-//! #### Controllers
+//! #### [`Controller`](controller::Controller)s
 //!
-//! Additionally you can create a struct that implements the `Controller` trait to replace the closure from the previous example.
+//! Additionally you can create a struct that implements the [`Controller`](controller::Controller) trait to replace the closure from the previous example.
 //!
 //! Here is an example of how this can be applied :
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,63 +1,65 @@
 //! # iter-tree
-
-//! This library provide an easy way to transform iterator into tree. This can be useful when building simple parsers to convert a stream of token into a tree of token.
-
-//! It provide two types of tree:
-
-//! - The default one, [`Tree`](tree::Tree) is based on [`Vec`] from the standard library.
-
-//! - The second one, [`TreeDeque`](tree_deque::TreeDeque) is based on [`VecDeque`](std::collections::VecDeque) from the standard libray. <br/> To get this one, you have to activate the `deque` feature flag.
 //!
-//! The goals for the future of this crate includes but are not limited to :
-//! - Providing other types of Trees, notably some that separate the item that inited and terminated a branch.
-//! - Adding more methods to build Trees such as for example a `tree_map` and `tree_deque_map` method that would map the item before including it in the Tree.
+//! This library provides an easy way to convert between iterators and tree structures in both directions. This can be useful when building simple parsers to convert a stream of token into a tree of token.
+
+//! It extends iterators with two functions : 
+//! 
+//! - `tree` that maps the iterator to an iterator of `Tree` that can be collected to a `Tree`.
+//! 
+//! - `tree_deque` that maps the iterator to an iterator of `TreeDeque` that can be collected to a `TreeDeque`.
+//!   To get this one, you have to activate the `deque` feature flag.
+//!
+//! Both type of trees implement the `IntoIterator` trait.
 //!
 //! ## Usage
 //!
-//! The creation of a tree is controlled with the [`BranchControl`](controller::BranchControl) enum.
-//!
+//! The creation of a tree is controlled with the `BranchControl` enum.
 //! This enum has three variants :
 //!
-//! - [`BranchControl::Start`](controller::BranchControl::Start)
+//! - BranchControl::Start
 //!   - Is used to start nesting the items of the iterator into a new branch.
-//! - [`BranchControl::Continue`](controller::BranchControl::Continue)
+//! - BranchControl::Continue
 //!   - Is used to keep the item in the same branch as the previous ones
-//! - [`BranchControl::End`](controller::BranchControl::End)
+//! - BranchControl::End
 //!   - Is used to get back up to the previous branch to put the next items.
 //!
 //! > Note:
-//! >
-//! > When filling a branch started with [`BranchControl::Start`](controller::BranchControl::Start), no crash or error will happens if the iterator ends before encountering the corresponding [`BranchControl::End`](controller::BranchControl::End).
-//! > Similarly, any unmatched [`BranchControl::End`](controller::BranchControl::End) will simply be ignored.
-//! >
+//! > 
+//! > When filling a branch started with `BranchControl::Start`, no crash or error will happens if the iterator ends before encountering the corresponding `BranchControl::End`.
+//! > Similarly, any unmatched `BranchControl::End` will simply be ignored.
+//! > 
 //! > If you want to check for these kind of situations, you can use a trick such as the depth counter showed in the below example.
-
-//! ### Example
+//!
+//! ## Example
 //!
 //! ```rust
 //! use iter_tree::prelude::*;
 //!
 //! let mut depth = 0;
 //!
-//! let tree = "a+(b+c)+d"
+//! let before = String::from("a+(b+c)+d");
+//!
+//! let tree = before
 //!     .chars()
 //!     .into_iter()
 //!     .tree(|&item: &char| match item {
 //!         '(' => {
 //!             depth += 1;
 //!             BranchControl::Start
-//!         }
-//!         ')' => {
+//!         },
+//!         ')' => { 
 //!             depth -= 1;
 //!             BranchControl::End
-//!         }
+//!         },
 //!         _ => BranchControl::Continue,
 //!     })
 //!     .collect::<Tree<char>>();
 //!
-//! println!("{tree:?}");
+//! println!("{tree:#?}");
 //!
-//! assert_eq!(0, depth);
+//! let after: String = tree.into_iter().collect();
+//!
+//! assert_eq!(before, after);
 //! ```
 //!
 //! ```bash
@@ -98,9 +100,9 @@
 //! )
 //! ```
 //!
-//! ### To go further
+//! #### Controllers
 //!
-//! Additionally you can create a struct that implements the [`Controller`](controller::Controller) trait to replace the closure from the previous example.
+//! Additionally you can create a struct that implements the `Controller` trait to replace the closure from the previous example.
 //!
 //! Here is an example of how this can be applied :
 //!
@@ -117,7 +119,7 @@
 //!         self.stack.is_empty()
 //!     }
 //! }
-
+//!
 //! impl Controller<char> for &mut StackController<char> {
 //!     fn control_branch(&mut self, item: &char) -> BranchControl {
 //!         let &c = item;
@@ -161,13 +163,20 @@
 //!
 //! assert!(controller.is_empty());
 //!
-//!
 //! let mut controller = StackController::default();
 //!
 //! let _b = "<(>)".chars().tree(&mut controller).collect::<Tree<_>>();
 //!
 //! assert!(!controller.is_empty())
 //! ```
+//!
+//! ## What's next ?
+//!
+//! The goals for the future of this crate includes but are not limited to :
+//!
+//! - Adding more methods to build Trees such as for example a `tree_map` and `tree_deque_map` method that would map the item before including it in the Tree.
+//!
+//! - Providing other types of Trees, notably some that separate the item that inited and terminated a branch.
 
 pub mod controller;
 
@@ -295,6 +304,8 @@ mod tests {
                 })
                 .collect::<Tree<char>>();
 
+            println!("{tree:#?}");
+
             let after: String = tree.into_iter().collect();
 
             assert_eq!(before, after);
@@ -357,8 +368,6 @@ mod tests {
                 .tree_deque(&mut parser)
                 .collect::<TreeDeque<char>>();
 
-            //print_type_of(&_1);
-
             assert!(parser.is_empty());
         }
 
@@ -387,6 +396,8 @@ mod tests {
                     _ => BranchControl::Continue,
                 })
                 .collect::<TreeDeque<char>>();
+
+            println!("{tree:#?}");
 
             let after: String = tree.into_iter().collect();
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
-pub use crate::controller::*;
+pub use crate::controller::{BranchControl, Controller};
 
 #[cfg(feature = "vec")]
-pub use crate::tree::*;
+pub use crate::tree::{Tree, Treeable};
 
 #[cfg(feature = "deque")]
-pub use crate::tree_deque::*;
+pub use crate::tree_deque::{TreeDeque, TreeDequeable};

--- a/src/tree/adapter.rs
+++ b/src/tree/adapter.rs
@@ -1,16 +1,5 @@
-use crate::controller::*;
-
-#[derive(Debug)]
-pub enum Tree<T> {
-    Leaf(T),
-    Branch(Vec<Tree<T>>),
-}
-
-impl<Item> FromIterator<Tree<Item>> for Tree<Item> {
-    fn from_iter<T: IntoIterator<Item = Tree<Item>>>(iter: T) -> Self {
-        Tree::Branch(Vec::from_iter(iter))
-    }
-}
+use super::Tree;
+use crate::controller::{BranchControl, Controller};
 
 pub struct TreeAdapter<I, T, C>
 where

--- a/src/tree/into_iter.rs
+++ b/src/tree/into_iter.rs
@@ -1,0 +1,75 @@
+use std::iter::{once, Once};
+
+use super::Tree;
+
+pub enum IntoIter<T> {
+    Unique(Once<T>),
+    Multiple(BranchIntoIter<T>),
+}
+
+impl<T> From<Tree<T>> for IntoIter<T> {
+    fn from(value: Tree<T>) -> Self {
+        match value {
+            Tree::Leaf(value) => Self::Unique(once(value)),
+            Tree::Branch(multiple) => Self::Multiple(BranchIntoIter {
+                state: BranchIterState::Normal,
+                iter: multiple.into_iter(),
+            }),
+        }
+    }
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            IntoIter::Unique(once) => once.next(),
+            IntoIter::Multiple(multiple) => multiple.next(),
+        }
+    }
+}
+
+pub enum BranchIterState<T> {
+    Normal,
+    Recursion(Box<BranchIntoIter<T>>),
+}
+
+pub struct BranchIntoIter<T> {
+    state: BranchIterState<T>,
+    iter: std::vec::IntoIter<Tree<T>>,
+}
+
+impl<T> Iterator for BranchIntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.state {
+            BranchIterState::Normal => {
+                let next = self.iter.next()?;
+
+                match next {
+                    Tree::Leaf(value) => Some(value),
+                    Tree::Branch(trees) => {
+                        self.state = BranchIterState::Recursion(Box::new(Self {
+                            state: BranchIterState::Normal,
+                            iter: trees.into_iter(),
+                        }));
+                        self.next()
+                    }
+                }
+            }
+            BranchIterState::Recursion(rec) => {
+                let next = rec.next();
+
+                match next {
+                    None => {
+                        self.state = BranchIterState::Normal;
+                        self.next()
+                    }
+                    value => value,
+                }
+            }
+        }
+    }
+}

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,0 +1,26 @@
+mod adapter;
+mod into_iter;
+pub use adapter::Treeable;
+use into_iter::IntoIter;
+
+#[derive(Debug)]
+pub enum Tree<T> {
+    Leaf(T),
+    Branch(Vec<Tree<T>>),
+}
+
+impl<Item> FromIterator<Tree<Item>> for Tree<Item> {
+    fn from_iter<T: IntoIterator<Item = Tree<Item>>>(iter: T) -> Self {
+        Tree::Branch(Vec::from_iter(iter))
+    }
+}
+
+impl<Item> IntoIterator for Tree<Item> {
+    type Item = Item;
+
+    type IntoIter = IntoIter<Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into()
+    }
+}

--- a/src/tree_deque/adapter.rs
+++ b/src/tree_deque/adapter.rs
@@ -1,18 +1,7 @@
 use std::collections::VecDeque;
 
-use crate::controller::*;
-
-#[derive(Debug)]
-pub enum TreeDeque<T> {
-    Leaf(T),
-    Branch(VecDeque<TreeDeque<T>>),
-}
-
-impl<Item> FromIterator<TreeDeque<Item>> for TreeDeque<Item> {
-    fn from_iter<T: IntoIterator<Item = TreeDeque<Item>>>(iter: T) -> Self {
-        TreeDeque::Branch(VecDeque::from_iter(iter))
-    }
-}
+use super::TreeDeque;
+use crate::controller::{BranchControl, Controller};
 
 pub struct TreeDequeAdapter<I, T, C>
 where

--- a/src/tree_deque/into_iter.rs
+++ b/src/tree_deque/into_iter.rs
@@ -1,0 +1,78 @@
+use std::{
+    collections::VecDeque,
+    iter::{once, Once},
+};
+
+use super::TreeDeque;
+
+pub enum IntoIter<T> {
+    Unique(Once<T>),
+    Multiple(BranchIntoIter<T>),
+}
+
+impl<T> From<TreeDeque<T>> for IntoIter<T> {
+    fn from(value: TreeDeque<T>) -> Self {
+        match value {
+            TreeDeque::Leaf(value) => Self::Unique(once(value)),
+            TreeDeque::Branch(multiple) => Self::Multiple(BranchIntoIter {
+                state: BranchIterState::Normal,
+                trees: multiple,
+            }),
+        }
+    }
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            IntoIter::Unique(once) => once.next(),
+            IntoIter::Multiple(multiple) => multiple.next(),
+        }
+    }
+}
+
+pub enum BranchIterState<T> {
+    Normal,
+    Recursion(Box<BranchIntoIter<T>>),
+}
+
+pub struct BranchIntoIter<T> {
+    state: BranchIterState<T>,
+    trees: VecDeque<TreeDeque<T>>,
+}
+
+impl<T> Iterator for BranchIntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.state {
+            BranchIterState::Normal => {
+                let next = self.trees.pop_front()?;
+
+                match next {
+                    TreeDeque::Leaf(value) => Some(value),
+                    TreeDeque::Branch(trees) => {
+                        self.state = BranchIterState::Recursion(Box::new(Self {
+                            state: BranchIterState::Normal,
+                            trees: trees,
+                        }));
+                        self.next()
+                    }
+                }
+            }
+            BranchIterState::Recursion(rec) => {
+                let next = rec.next();
+
+                match next {
+                    None => {
+                        self.state = BranchIterState::Normal;
+                        self.next()
+                    }
+                    value => value,
+                }
+            }
+        }
+    }
+}

--- a/src/tree_deque/mod.rs
+++ b/src/tree_deque/mod.rs
@@ -1,0 +1,28 @@
+mod adapter;
+mod into_iter;
+
+pub use adapter::TreeDequeable;
+use into_iter::IntoIter;
+use std::collections::VecDeque;
+
+#[derive(Debug)]
+pub enum TreeDeque<T> {
+    Leaf(T),
+    Branch(VecDeque<TreeDeque<T>>),
+}
+
+impl<Item> FromIterator<TreeDeque<Item>> for TreeDeque<Item> {
+    fn from_iter<T: IntoIterator<Item = TreeDeque<Item>>>(iter: T) -> Self {
+        TreeDeque::Branch(VecDeque::from_iter(iter))
+    }
+}
+
+impl<Item> IntoIterator for TreeDeque<Item> {
+    type Item = Item;
+
+    type IntoIter = IntoIter<Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into()
+    }
+}


### PR DESCRIPTION
Implemented [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) trait on Tree and TreeDeque